### PR TITLE
lint fix

### DIFF
--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -2,12 +2,12 @@ import decimal
 import json
 import logging
 import os
-import PIL
 from copy import deepcopy
 from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 import pandas as pd
+import PIL
 
 from mlflow.exceptions import INVALID_PARAMETER_VALUE, MlflowException
 from mlflow.models import Model

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -9,7 +9,6 @@ import json
 import logging
 import os
 import pathlib
-import PIL
 import re
 import sys
 from functools import lru_cache
@@ -18,6 +17,7 @@ from urllib.parse import urlparse
 
 import numpy as np
 import pandas as pd
+import PIL
 import yaml
 
 from mlflow import pyfunc
@@ -2611,16 +2611,16 @@ class _TransformersWrapper:
             except binascii.Error:
                 return False
 
-        if isinstance(data, list) and  all(isinstance(element, dict) for element in data):
-           lst_data= []
-           for item in data:
+        if isinstance(data, list) and all(isinstance(element, dict) for element in data):
+            lst_data = []
+            for item in data:
                 data_ele = next(iter(item.values()))
                 if isinstance(data_ele, str):
                     # base64 encoded image comes as string
                     if not is_base64_image(data_ele):
                         self._validate_str_input_uri_or_file(data_ele)
                 lst_data.append(data_ele)
-           return lst_data
+            return lst_data
         elif isinstance(data, str):
             if not is_base64_image(data):
                 self._validate_str_input_uri_or_file(data)
@@ -2711,7 +2711,6 @@ class _TransformersWrapper:
             self._validate_str_input_uri_or_file(data)
         return data
 
-
     @staticmethod
     def _validate_str_input_uri_or_file(input_str):
         """
@@ -2728,18 +2727,20 @@ class _TransformersWrapper:
                 return all([result.scheme, result.netloc])
             except ValueError:
                 return False
+
         def validate_nested_list(lst):
             for item in lst:
                 if isinstance(item, list):
                     validate_nested_list(item)
                 else:
                     validate_single_input(key, item)
+
         def validate_input(key, value):
             # Use pathlib to handle file paths
-            #input_path = os.Path(value)
+            # input_path = os.Path(value)
 
             # Check if it's a valid file path or URI
-            #valid_input = input_path.is_file() or is_uri(value)
+            # valid_input = input_path.is_file() or is_uri(value)
             valid_uri = os.path.isfile(input_str) or is_uri(input_str)
 
             if not valid_uri:
@@ -2748,16 +2749,19 @@ class _TransformersWrapper:
                     "audio or image files must be either a file location or a uri.",
                     error_code=BAD_REQUEST,
                 )
+
         def validate_single_input(key, value):
             if isinstance(value, list):
                 validate_nested_list(value)
             else:
                 validate_input(key, value)
+
         if isinstance(input_str, dict):
             for key, value in input_str.items():
                 validate_input(key, value)
         else:
             validate_input(None, input_str)
+
 
 @experimental
 @autologging_integration(FLAVOR_NAME)

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -3,11 +3,11 @@ import datetime as dt
 import importlib.util
 import json
 import string
-from PIL import Image
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple, TypedDict, Union
 
 import numpy as np
+from PIL import Image
 
 from mlflow.exceptions import MlflowException
 from mlflow.utils.annotations import experimental
@@ -53,7 +53,7 @@ class DataType(Enum):
         dt.date,
     )
     """64b datetime data."""
-    pilimage = (9, "PILImage" , "PILImage", object, Image.Image)
+    pilimage = (9, "PILImage", "PILImage", object, Image.Image)
     """pil image."""
 
     def __repr__(self):

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -1,10 +1,10 @@
 import logging
 import warnings
-import PIL
 from typing import Any, Dict, List, Optional
 
 import numpy as np
 import pandas as pd
+import PIL
 
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -998,6 +998,7 @@ def test_transformers_log_model_with_no_registered_model_name(small_vision_model
         )
         mlflow.tracking._model_registry.fluent._register_model.assert_not_called()
 
+
 def test_transformers_save_persists_requirements_in_mlflow_directory(
     small_qa_pipeline, model_path, transformers_custom_env
 ):
@@ -1366,11 +1367,13 @@ def read_image(filename):
     with open(image_path, "rb") as f:
         return f.read()
 
+
 def is_base64_image(s):
     try:
         return base64.b64encode(base64.b64decode(s)).decode("utf-8") == s
     except Exception:
         return False
+
 
 @pytest.mark.parametrize(
     "inference_payload",
@@ -1382,7 +1385,7 @@ def is_base64_image(s):
     ],
 )
 def test_vision_pipeline_pyfunc_load_and_infer(small_vision_model, model_path, inference_payload):
-    if Version(transformers.__version__) < Version('4.29'):
+    if Version(transformers.__version__) < Version("4.29"):
         if is_base64_image(inference_payload):
             return
     signature = infer_signature(
@@ -1397,7 +1400,6 @@ def test_vision_pipeline_pyfunc_load_and_infer(small_vision_model, model_path, i
     pyfunc_loaded = mlflow.pyfunc.load_model(model_path)
     predictions = pyfunc_loaded.predict(inference_payload)
     assert len(predictions) != 0
-
 
 
 @pytest.mark.skipif(RUNNING_IN_GITHUB_ACTIONS, reason=GITHUB_ACTIONS_SKIP_REASON)
@@ -2127,11 +2129,14 @@ def test_qa_pipeline_pyfunc_predict(small_qa_pipeline):
     [
         [os.path.join(pathlib.Path(__file__).parent.parent, "datasets", "cat.png")],
         [image_url, image_url],
-        [base64.b64encode(read_image("cat_image.jpg")).decode("utf-8"), base64.b64encode(read_image("tiger_cat.jpg")).decode("utf-8")],
+        [
+            base64.b64encode(read_image("cat_image.jpg")).decode("utf-8"),
+            base64.b64encode(read_image("tiger_cat.jpg")).decode("utf-8"),
+        ],
     ],
 )
 def test_vision_pipeline_pyfunc_predict(small_vision_model, inference_payload):
-    if transformers.__version__ < '4.29':
+    if transformers.__version__ < "4.29":
         if is_base64_image(inference_payload[0]):
             return
     artifact_path = "image_classification_model"
@@ -2143,9 +2148,7 @@ def test_vision_pipeline_pyfunc_predict(small_vision_model, inference_payload):
             artifact_path=artifact_path,
         )
         model_uri = mlflow.get_artifact_uri(artifact_path)
-    inference_payload = json.dumps({
-        "inputs" : inference_payload
-    })
+    inference_payload = json.dumps({"inputs": inference_payload})
     response = pyfunc_serve_and_score_model(
         model_uri,
         data=inference_payload,
@@ -3583,7 +3586,7 @@ def test_vision_pipeline_pyfunc_predict_with_kwargs(small_vision_model):
                 mlflow.transformers.generate_signature_output(
                     small_vision_model, {"images": image_file_paths}
                 ),
-                params=parameters
+                params=parameters,
             ),
         )
         model_uri = mlflow.get_artifact_uri(artifact_path)
@@ -3597,7 +3600,7 @@ def test_vision_pipeline_pyfunc_predict_with_kwargs(small_vision_model):
 
     predictions = PredictionsResponse.from_json(response.content.decode("utf-8")).get_predictions()
     assert len(predictions) == len(image_file_paths)
-    assert len(predictions.iloc[0]) == parameters['top_k']
+    assert len(predictions.iloc[0]) == parameters["top_k"]
 
 
 def test_qa_pipeline_pyfunc_predict_with_kwargs(small_qa_pipeline):

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -81,7 +81,7 @@ _IMAGE_PROCESSOR_API_CHANGE_VERSION = "4.26.0"
 # runners#supported-runners-and-hardware-resources for instance specs.
 RUNNING_IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 GITHUB_ACTIONS_SKIP_REASON = "Test consumes too much memory"
-image_url = "http://images.cocodataset.org/val2017/000000039769.jpg"
+image_url = "https://github.com/mlflow/mlflow/blob/master/tests/datasets/cat_image.jpg"
 # Test that can only be run locally:
 # - Summarization pipeline tests
 # - TextClassifier pipeline tests
@@ -1380,14 +1380,15 @@ def is_base64_image(s):
     [
         image_url,
         os.path.join(pathlib.Path(__file__).parent.parent, "datasets", "cat.png"),
-        base64.b64encode(read_image("cat_image.jpg")).decode("utf-8"),
+        "base64",
         Image.open(os.path.join(pathlib.Path(__file__).parent.parent, "datasets", "cat.png")),
     ],
 )
 def test_vision_pipeline_pyfunc_load_and_infer(small_vision_model, model_path, inference_payload):
-    if Version(transformers.__version__) < Version("4.29"):
-        if is_base64_image(inference_payload):
+    if inference_payload == "base64":
+        if Version(transformers.__version__) < Version("4.29"):
             return
+        inference_payload = base64.b64encode(read_image("cat_image.jpg")).decode("utf-8")
     signature = infer_signature(
         inference_payload,
         mlflow.transformers.generate_signature_output(small_vision_model, inference_payload),
@@ -2129,16 +2130,16 @@ def test_qa_pipeline_pyfunc_predict(small_qa_pipeline):
     [
         [os.path.join(pathlib.Path(__file__).parent.parent, "datasets", "cat.png")],
         [image_url, image_url],
-        [
-            base64.b64encode(read_image("cat_image.jpg")).decode("utf-8"),
-            base64.b64encode(read_image("tiger_cat.jpg")).decode("utf-8"),
-        ],
+        "base64",
     ],
 )
 def test_vision_pipeline_pyfunc_predict(small_vision_model, inference_payload):
-    if transformers.__version__ < "4.29":
-        if is_base64_image(inference_payload[0]):
+    if not isinstance(inference_payload, list) and inference_payload == "base64":
+        if transformers.__version__ < "4.29":
             return
+        inference_payload = [
+            base64.b64encode(read_image("cat_image.jpg")).decode("utf-8"),
+        ]
     artifact_path = "image_classification_model"
 
     # Log the image classification model
@@ -3566,7 +3567,7 @@ def test_save_model_card_with_non_utf_characters(tmp_path, model_name):
 def test_vision_pipeline_pyfunc_predict_with_kwargs(small_vision_model):
     artifact_path = "image_classification_model"
 
-    image_file_paths = [image_url, image_url]
+    image_file_paths = [image_url]
     parameters = {
         "top_k": 2,
     }
@@ -3583,9 +3584,7 @@ def test_vision_pipeline_pyfunc_predict_with_kwargs(small_vision_model):
             artifact_path=artifact_path,
             signature=infer_signature(
                 image_file_paths,
-                mlflow.transformers.generate_signature_output(
-                    small_vision_model, {"images": image_file_paths}
-                ),
+                mlflow.transformers.generate_signature_output(small_vision_model, image_file_paths),
                 params=parameters,
             ),
         )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MadhuM02/mlflow/pull/3?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/3/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 3
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
